### PR TITLE
Fixes for launcher.config / WorldQueue.config XML Changes and version bump to 0.2.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -78,6 +78,10 @@ Changes
 		Support for Python 3.x, PyQt 4.6+ and OpenSSL 1.x
 		Enable server authentication for better security (Python 3.2+ only currently)
 
-0.2.1	Fixes for WorldQueue.config XML Changes and version bump to 0.2.1
+0.2.1	Fixes for launcher.config XML Changes and version bump to 0.2.1
 		Fix for 20-Nov-2014 slight changes to WorldQueue.config by Turbine which
 		broke pylotro.
+
+0.2.2	Fixes for Update 15.1 changes to launcher.config argument template.  Turbine is now
+		using crashserverurl and DefaultUploadThrottleMbps in the argument template.
+		Version bump to 0.2.2.

--- a/ChangeLog
+++ b/ChangeLog
@@ -77,3 +77,7 @@ Changes
 		Fix problems when path settings have trailing (back-)slashes.
 		Support for Python 3.x, PyQt 4.6+ and OpenSSL 1.x
 		Enable server authentication for better security (Python 3.2+ only currently)
+
+0.2.1	Fixes for WorldQueue.config XML Changes and version bump to 0.2.1
+		Fix for 20-Nov-2014 slight changes to WorldQueue.config by Turbine which
+		broke pylotro.

--- a/PyLotRO.iss
+++ b/PyLotRO.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{EB42F98E-B61B-4EE7-AF06-CAAF8D1825A3}
 AppName=PyLotRO
-AppVerName=PyLotRO 0.2.1
+AppVerName=PyLotRO 0.2.2
 AppPublisher=AJackson
 AppPublisherURL=http://www.lotrolinux.com
 AppSupportURL=http://www.lotrolinux.com

--- a/PyLotRO.iss
+++ b/PyLotRO.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{EB42F98E-B61B-4EE7-AF06-CAAF8D1825A3}
 AppName=PyLotRO
-AppVerName=PyLotRO 0.2.0
+AppVerName=PyLotRO 0.2.1
 AppPublisher=AJackson
 AppPublisherURL=http://www.lotrolinux.com
 AppSupportURL=http://www.lotrolinux.com

--- a/PyLotROLauncher/Information.py
+++ b/PyLotROLauncher/Information.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-Version = "0.2.0"
+Version = "0.2.1"
 Description = "LOTRO/DDO Launcher"
 Author = "Alan Jackson"
 Email = "ajackson@bcs.org.uk"

--- a/PyLotROLauncher/Information.py
+++ b/PyLotROLauncher/Information.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-Version = "0.2.1"
+Version = "0.2.2"
 Description = "LOTRO/DDO Launcher"
 Author = "Alan Jackson"
 Email = "ajackson@bcs.org.uk"

--- a/PyLotROLauncher/MainWindow.py
+++ b/PyLotROLauncher/MainWindow.py
@@ -367,6 +367,7 @@ class MainWindow:
 			self.settings.gameDir, self.settings.wineProg, self.settings.wineDebug,
 			self.settings.winePrefix, self.settings.hiResEnabled, self.settings.app,
 			self.osType, self.valHomeDir, self.gameType.icoFile, self.rootDir,
+			self.worldQueueConfig.crashreceiver, self.worldQueueConfig.DefaultUploadThrottleMbps,
 			self.worldQueueConfig.bugurl, self.worldQueueConfig.authserverurl,
 			self.worldQueueConfig.supporturl, self.worldQueueConfig.supportserviceurl,
 			self.worldQueueConfig.glsticketlifetime)

--- a/PyLotROLauncher/MainWindow.py
+++ b/PyLotROLauncher/MainWindow.py
@@ -366,7 +366,10 @@ class MainWindow:
 			self.langConfig.langList[self.uiMain.cboLanguage.currentIndex()].code,
 			self.settings.gameDir, self.settings.wineProg, self.settings.wineDebug,
 			self.settings.winePrefix, self.settings.hiResEnabled, self.settings.app,
-			self.osType, self.valHomeDir, self.gameType.icoFile, self.rootDir)
+			self.osType, self.valHomeDir, self.gameType.icoFile, self.rootDir,
+			self.worldQueueConfig.bugurl, self.worldQueueConfig.authserverurl,
+			self.worldQueueConfig.supporturl, self.worldQueueConfig.supportserviceurl,
+			self.worldQueueConfig.glsticketlifetime)
 
 		self.winMain.hide()
 		game.Run()

--- a/PyLotROLauncher/PyLotROUtils.py
+++ b/PyLotROLauncher/PyLotROUtils.py
@@ -458,6 +458,11 @@ class WorldQueueConfig:
 	def __init__(self, urlConfigServer, usingDND, baseDir, osType):
 		self.gameClientFilename = ""
 		self.gameClientArgTemplate = ""
+		self.bugurl = ""
+		self.authserverurl = ""
+		self.supporturl = ""
+		self.supportserviceurl = ""
+		self.glsticketlifetime = ""
 		self.newsFeedURL = ""
 		self.newsStyleSheetURL = ""
 		self.patchProductCode = ""
@@ -487,10 +492,20 @@ class WorldQueueConfig:
 				nodes = doc.getElementsByTagName("appSettings")[0].childNodes
 				for node in nodes:
 					if node.nodeType == node.ELEMENT_NODE:
-						if node.getAttribute("key") == "GameClient.Filename":
+						if node.getAttribute("key") == "GameClient.WIN32.Filename":
 							self.gameClientFilename = node.getAttribute("value")
-						elif node.getAttribute("key") == "GameClient.ArgTemplate":
+						elif node.getAttribute("key") == "GameClient.WIN32.ArgTemplate":
 							self.gameClientArgTemplate = node.getAttribute("value")
+						elif node.getAttribute("key") == "GameClient.Arg.bugurl":
+						        self.bugurl = node.getAttribute("value")
+						elif node.getAttribute("key") == "GameClient.Arg.authserverurl":
+						        self.authserverurl = node.getAttribute("value")
+						elif node.getAttribute("key") == "GameClient.Arg.supporturl":
+						        self.supporturl = node.getAttribute("value")
+						elif node.getAttribute("key") == "GameClient.Arg.supportserviceurl":
+						        self.supportserviceurl = node.getAttribute("value")
+						elif node.getAttribute("key") == "GameClient.Arg.glsticketlifetime":
+							self.glsticketlifetime = node.getAttribute("value")
 						elif node.getAttribute("key") == "URL.NewsFeed":
 							self.newsFeedURL = node.getAttribute("value")
 						elif node.getAttribute("key") == "URL.NewsStyleSheet":

--- a/PyLotROLauncher/PyLotROUtils.py
+++ b/PyLotROLauncher/PyLotROUtils.py
@@ -458,6 +458,8 @@ class WorldQueueConfig:
 	def __init__(self, urlConfigServer, usingDND, baseDir, osType):
 		self.gameClientFilename = ""
 		self.gameClientArgTemplate = ""
+		self.crashreceiver = ""
+		self.DefaultUploadThrottleMbps = ""
 		self.bugurl = ""
 		self.authserverurl = ""
 		self.supporturl = ""
@@ -496,6 +498,10 @@ class WorldQueueConfig:
 							self.gameClientFilename = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.WIN32.ArgTemplate":
 							self.gameClientArgTemplate = node.getAttribute("value")
+						elif node.getAttribute("key") == "GameClient.Arg.crashreceiver":
+						        self.crashreceiver = node.getAttribute("value")
+						elif node.getAttribute("key") == "GameClient.Arg.DefaultUploadThrottleMbps":
+						        self.DefaultUploadThrottleMbps = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.bugurl":
 						        self.bugurl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.authserverurl":

--- a/PyLotROLauncher/StartGame.py
+++ b/PyLotROLauncher/StartGame.py
@@ -34,8 +34,9 @@ import sys, os.path
 class StartGame:
 	def __init__(self, parent, appName, argTemplate, account, server, ticket,
 		chatServer, language, runDir, wineProgram, wineDebug, winePrefix, 
-		hiResEnabled, wineApp, osType, homeDir, icoFileIn, rootDir, bugurl,
-		authserverurl, supporturl, supportserviceurl, glsticketlifetime):
+		hiResEnabled, wineApp, osType, homeDir, icoFileIn, rootDir,
+		crashreceiver, DefaultUploadThrottleMbps, bugurl, authserverurl,
+		supporturl, supportserviceurl, glsticketlifetime):
 
 		self.winMain = parent
 		self.homeDir = homeDir
@@ -87,6 +88,7 @@ class StartGame:
 
 		gameParams = argTemplate.replace("{SUBSCRIPTION}", account).replace("{LOGIN}", server)\
 			.replace("{GLS}", ticket).replace("{CHAT}", chatServer).replace("{LANG}", language)\
+			.replace("{CRASHRECEIVER}", crashreceiver).replace("{UPLOADTHROTTLE}", DefaultUploadThrottleMbps)\
 			.replace("{BUGURL}", bugurl).replace("{AUTHSERVERURL}", authserverurl)\
 			.replace("{GLSTICKETLIFETIME}", glsticketlifetime).replace("{SUPPORTURL}", supporturl)\
 			.replace("{SUPPORTSERVICEURL}",supportserviceurl)

--- a/PyLotROLauncher/StartGame.py
+++ b/PyLotROLauncher/StartGame.py
@@ -34,7 +34,8 @@ import sys, os.path
 class StartGame:
 	def __init__(self, parent, appName, argTemplate, account, server, ticket,
 		chatServer, language, runDir, wineProgram, wineDebug, winePrefix, 
-		hiResEnabled, wineApp, osType, homeDir, icoFileIn, rootDir):
+		hiResEnabled, wineApp, osType, homeDir, icoFileIn, rootDir, bugurl,
+		authserverurl, supporturl, supportserviceurl, glsticketlifetime):
 
 		self.winMain = parent
 		self.homeDir = homeDir
@@ -84,8 +85,11 @@ class StartGame:
 		self.command = ""
 		self.arguments = []
 
-		gameParams = argTemplate.replace("{0}", account).replace("{1}", server)\
-			.replace("{2}", ticket).replace("{3}", chatServer).replace("{4}", language)
+		gameParams = argTemplate.replace("{SUBSCRIPTION}", account).replace("{LOGIN}", server)\
+			.replace("{GLS}", ticket).replace("{CHAT}", chatServer).replace("{LANG}", language)\
+			.replace("{BUGURL}", bugurl).replace("{AUTHSERVERURL}", authserverurl)\
+			.replace("{GLSTICKETLIFETIME}", glsticketlifetime).replace("{SUPPORTURL}", supporturl)\
+			.replace("{SUPPORTSERVICEURL}",supportserviceurl)
 
 		if not hiResEnabled:
 			gameParams = gameParams + " --HighResOutOfDate"


### PR DESCRIPTION
Fixes for pylotro following format changes to WorldQueue.config by Turbine on 20-Nov-2014 which broke pylotro functionality.  Initial patches by blosco posted to LOTRO forums in the following thread, with additional patches provided by myself to complete the new argument template.

See relevant thread here:
https://www.lotro.com/forums/showthread.php?559349-Can-t-log-in-with-Linux-at-the-moment-anybody-else
